### PR TITLE
docs: clarify $USER in HPCDME properties

### DIFF
--- a/docs/HPCDME/setup.md
+++ b/docs/HPCDME/setup.md
@@ -33,6 +33,8 @@ cp hpcdme.properties-sample hpcdme.properties
 
 Some of the parameters in this file have become obsolete over the course of time and are commmented out. Change paths and default values, as needed
 
+> Note: replace `$USER` with your actual username in the properties file. Bash variables will not be interpolated.
+
 ```bash
 #HPC DME Server URL
 #Production server settings


### PR DESCRIPTION
It seems bash variables aren't interpolated in the HPCDME Properties file. This PR adds a note to the docs to clarify that you need to use your actual username in that file rather than $USER.