### PR TITLE
docs: ToC for mamba migration guide

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -37,3 +37,4 @@ format:
     embed-resources: false
     code-fold: true
     toc: true
+    toc-title: "Table of Contents"

--- a/docs/conda_to_mamba.md
+++ b/docs/conda_to_mamba.md
@@ -2,6 +2,7 @@
 title: Move from Conda to Mamba
 description: "Export Conda environments, uninstall conda, install mamba and rebuild new Mamba environments"
 author: "[Vishal Koparde](https://github.com/kopardev)"
+toc-location: right-body
 ---
 
 # Migrating from Anaconda/Miniconda (**conda**) to **Miniforge** (**mamba**)


### PR DESCRIPTION
Hey @kopardev, there's no need to manually create a table of contents for any page in this repo because we have quarto set to do it automatically.

By default (set in `_quarto.yml`) we have all of our pages generate a floating toc in the right sidebar that moves as you scroll, e.g.
<img width="1080" height="621" alt="image" src="https://github.com/user-attachments/assets/7c393090-3931-4edb-b8e9-1c978ff92698" />

I've modified the mamba migration doc to remove the manual toc and have the quarto toc in 2 locations: in the right sidebar AND at the beginning of the body. This is set in the page's yaml header: `toc-location: right-body` and looks like this:
<img width="1080" height="1039" alt="image" src="https://github.com/user-attachments/assets/d3428d06-1f30-4e4c-943e-2327bdc9d247" />

