### PR TITLE
docs: Fixed links to precommit page

### DIFF
--- a/docs/GitHub/guide/0_overview.md
+++ b/docs/GitHub/guide/0_overview.md
@@ -19,6 +19,6 @@ author: "[Samantha Sevilla](https://github.com/slsevilla) & [Vishal Koparde](htt
 
 ## Best Practices
 
-- [Use Pre-commit Hooks](6_sop_precommit.md)
+- [Use Pre-commit Hooks](6_howto_precommit.md)
 - [CCBR Projects, new Pipelines](7_sop_projpipes.md)
 - [TechDev](8_sop_techdev.md)

--- a/docs/GitHub/guide/3_basic_repo.md
+++ b/docs/GitHub/guide/3_basic_repo.md
@@ -78,7 +78,7 @@ However, if you're updating an established repository, you may need to add some 
 
 - Pre-commit config files
 
-    Pre-commit hooks provide an automated way to style code, draw attention to typos, and validate commit messages. Learn more about pre-commit [here](https://ccbr.github.io/HowTos/GitHub/howto_precommit/).
+    Pre-commit hooks provide an automated way to style code, draw attention to typos, and validate commit messages. Learn more about pre-commit [here](6_howto_precommit.md).
     These files can be customized depending on the needs of the repo. For example, you don't need the hook for formatting R code if your repo does not and will never contain any R code.
 
     - [`.pre-commit-config.yaml`](https://github.com/CCBR/CCBR_NextflowTemplate/blob/main/.pre-commit-config.yaml)


### PR DESCRIPTION
## Changes

Fixed two links to the precommit page, which previously gave 404 error.

